### PR TITLE
Use vue-i18n with composition API

### DIFF
--- a/src/plugins/i18n.plugin.ts
+++ b/src/plugins/i18n.plugin.ts
@@ -12,6 +12,12 @@ import de from '../i18n/de'
 import en from '../i18n/en'
 
 export const i18n = createI18n({
+  // you must set legacy `false`, to use Composition API
+  // https://vue-i18n-next.intlify.dev/guide/advanced/composition.html
+  legacy: false, 
+  // Inject i18n property into component 
+  // https://vue-i18n-next.intlify.dev/guide/advanced/composition.html#implicit-with-injected-properties-and-functions
+  globalInjection: true, 
   locale: 'en',
   fallbackLocale: 'en',
   messages: { de, en },


### PR DESCRIPTION
This certainly break some stuff but this seem the direction taken by vue-i18n.  Notably, I'm not sure how to access `i18n.global.locale` in the routes.

The legacy API mode and composition API mode of vue-i18n do not seem compatible neither.
